### PR TITLE
Align second hand and second-based redraw

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -645,7 +645,7 @@ function drawClock(){
     }else{
       hand(R*0.78,10,aMin,mnColor);
     }
-  hand(R,5,aSec,'#d11');
+  hand(R-10,5,aSec,'#d11');
 
   // 6. 中心
   ctx.beginPath(); ctx.arc(0,0,8,0,2*Math.PI);
@@ -658,17 +658,29 @@ function drawClock(){
 // ====== 更新ループ ======
 function update(){ drawClock(); tick(); }
 let loopHandle;
+function scheduleNext(){
+  const delay = 1000 - (Date.now() % 1000);
+  loopHandle = setTimeout(()=>{
+    update();
+    scheduleNext();
+  }, delay);
+}
 function setLoop(active){
   if(active){
     if(!loopHandle){
       update();
-      loopHandle=setInterval(update,1000);
+      scheduleNext();
     }
   }else if(loopHandle){
-    clearInterval(loopHandle);
+    clearTimeout(loopHandle);
     loopHandle=null;
   }
 }
 setLoop(true);
-document.addEventListener('visibilitychange', ()=>setLoop(!document.hidden));
+document.addEventListener('visibilitychange', ()=>{
+  if(document.hidden){
+    if('speechSynthesis' in window) speechSynthesis.cancel();
+  }
+  setLoop(!document.hidden);
+});
 


### PR DESCRIPTION
## Summary
- Make second hand point to tick marks and sync at 1-second steps
- Redraw and timer tick aligned to real second boundaries, cancel speech on hide

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1f54737c833394d5d8c49a7975cd