### PR TITLE
Add alarm reset button and remaining time effect

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-body{margin:0;font-family:system-ui,-apple-system;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f6f7f9;height:100dvh;overflow:hidden;padding-top:12px;padding-bottom:8px}
+body{margin:0;font-family:system-ui,-apple-system;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f6f7f9;height:100dvh;overflow:hidden;padding-top:12px;padding-bottom:8px;-webkit-user-select:none;user-select:none}
 :root{--ctrl-size:14px;--pill-min-w:96px}
 #controls{margin:18px 0 12px;display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;justify-items:center}
 input[type=range]{width:100%;max-width:400px}
@@ -7,10 +7,13 @@ input[type=range]{width:100%;max-width:400px}
 #clock{aspect-ratio:1/1;touch-action:none;cursor:pointer}
 #gate{display:none}
 #gate button{padding:14px 18px;font-size:18px;font-weight:800;border:0;border-radius:16px;background:#007aff;color:#fff}
-#actions{visibility:hidden;margin:10px 0 12px}
+#actions{visibility:hidden;margin:10px 0 12px;display:flex;gap:12px}
 #actions.visible{visibility:visible}
 #actions button{padding:10px 14px;font-size:16px;font-weight:700;border:0;border-radius:12px;background:#0a84ff;color:#fff}
+#actions button.outline{background:#fff;color:#0a84ff;border:2px solid #0a84ff}
 #confettiLayer{position:fixed;inset:0;pointer-events:none;overflow:visible}
 .confetti{position:fixed;width:8px;height:8px;border-radius:2px;opacity:1;will-change:transform,opacity}
 .confetti.move{transition:transform 1200ms ease-out, opacity 1200ms ease-out}
+@keyframes floatUpFade{from{transform:translate(-50%,-50%);opacity:1}to{transform:translate(-50%,-150%);opacity:0}}
+.remainEffect{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);font-size:72px;font-weight:700;color:#0a84ff;pointer-events:none;animation:floatUpFade 1.2s ease-out forwards}
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,10 @@
   <span class="pill"><span id="nVal">5</span><span id="nUnit">分</span></span>
 </div>
 <canvas id="clock" width="600" height="600"></canvas>
-<div id="actions"><button id="nextBtn">終わった。次！</button></div>
+<div id="actions">
+  <button id="resetBtn" class="outline">アラーム再設定</button>
+  <button id="nextBtn">終わった。次！</button>
+</div>
 <script type="module" src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent text/object selection by disabling user-select on the page
- add 「アラーム再設定」 button and layout next/ reset buttons side-by-side
- replace pre-finish confetti with floating remaining-time animation and allow resetting without effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2efb7820833387f236b68f9384ad