### PR TITLE
Fix JavaScript initialization and pointer cancel issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,7 +5,7 @@ input[type=range]{width:100%;max-width:400px}
 .pill{background:#eef2ff;padding:6px 12px;border-radius:999px;font-weight:700;font-size:var(--ctrl-size);min-width:var(--pill-min-w);display:inline-flex;align-items:center;justify-content:center}
 .ctrlText{font-size:var(--ctrl-size)}
 #clock{aspect-ratio:1/1;touch-action:none;cursor:pointer}
-#gate{display:none}
+#gate{display:none;position:fixed;inset:0;align-items:center;justify-content:center;background:rgba(0,0,0,0.25);z-index:20}
 #gate button{padding:14px 18px;font-size:18px;font-weight:800;border:0;border-radius:16px;background:#007aff;color:#fff}
 #actions{visibility:hidden;margin:10px 0 12px;display:flex;gap:12px}
 #actions.visible{visibility:visible}

--- a/js/main.js
+++ b/js/main.js
@@ -3,9 +3,18 @@ let started=false, startTime=null, startSec=0, startHour=null, startMin=null;
 let audioUnlocked=false, jaVoice=null, audioCtx=null;
 
 function ensureAudioCtx(){
-  if(!audioCtx) audioCtx=new (window.AudioContext||window.webkitAudioContext)();
-  if(audioCtx.state==='suspended' && typeof audioCtx.resume==='function'){
-    audioCtx.resume().catch(()=>{});
+  if(audioCtx) return true;
+  try{
+    const Ctx=window.AudioContext||window.webkitAudioContext;
+    if(!Ctx) throw new Error('unsupported');
+    audioCtx=new Ctx();
+    if(audioCtx.state==='suspended' && typeof audioCtx.resume==='function'){
+      audioCtx.resume().catch(()=>{});
+    }
+    return true;
+  }catch(e){
+    audioCtx=null;
+    return false;
   }
 }
 
@@ -20,6 +29,10 @@ const gate=$('gate');
 const gateBtn=$('gateBtn');
 const nextBtn=$('nextBtn');
 const resetBtn=$('resetBtn');
+
+// Show gate only when audio APIs exist and are still locked
+const hasAudioApi = typeof window !== 'undefined' && (window.AudioContext || window.webkitAudioContext);
+if(gate && hasAudioApi && !audioUnlocked){ gate.style.display='flex'; }
 
 // ====== 分針ドラッグ用の状態 ======
 let dragging=false;       // ドラッグ中か
@@ -86,7 +99,9 @@ function speakOrBeep(msg){
 // ====== タップで開始 ======
 function unlock(){
   audioUnlocked=true;
-  ensureAudioCtx();
+  if(!ensureAudioCtx()){
+    audioUnlocked=false;
+  }
   gate.style.display='none';
   // ベースラインやスケジュールは initBaseline/reset が担当
 }
@@ -156,25 +171,19 @@ function confettiBurst(){
   // layer自体は維持（使い回し）
 }
 function showRemainTime(ms){
-  const sec=Math.ceil(ms/1000);
-  const m=Math.floor(sec/60);
-const sec = Math.ceil(ms / 1000);
-const m = Math.floor(sec / 60);
-const text = `${m}分`;
-const el = document.createElement('div');
-el.className = 'remainEffect';
-el.textContent = text;
-const clock = document.getElementById('clock');
-if (clock) {
-  const rect = clock.getBoundingClientRect();
-  const fontSize = rect.width / Math.max(1, text.length);
-  el.style.fontSize = fontSize + 'px';
-}
-document.body.appendChild(el);
-setTimeout(() => { el.remove(); }, 1300);
-
+  const sec = Math.ceil(ms / 1000);
+  const m = Math.floor(sec / 60);
+  const text = `${m}分`;
+  const el = document.createElement('div');
+  el.className = 'remainEffect';
+  el.textContent = text;
+  if (clock) {
+    const rect = clock.getBoundingClientRect();
+    const fontSize = rect.width / Math.max(1, text.length);
+    el.style.fontSize = fontSize + 'px';
+  }
   document.body.appendChild(el);
-  setTimeout(()=>{el.remove();},1300);
+  setTimeout(() => { el.remove(); }, 1300);
 }
 
 function resetState(){
@@ -200,6 +209,7 @@ function onNext(){
   }else{
     confettiBurst();
   }
+}
 
 function onResetAlarm(){
   resetState();
@@ -312,6 +322,10 @@ function commitTimer(){
   if(actions) actions.classList.add('visible');
   drawClock();
 }
+function endDrag(e){
+  dragging=false; dragMinIdx=null;
+  try{ clock.releasePointerCapture(e.pointerId); }catch(_){/* noop */}
+}
 function onPointerDown(e){
   ensureAudioUnlocked();
   if(!started || timerLocked) return;
@@ -320,10 +334,12 @@ function onPointerDown(e){
   e.preventDefault();
 }
 function onPointerMove(e){ if(dragging && !timerLocked){ updateDrag(e); e.preventDefault(); } }
-function onPointerUp(e){ if(!dragging||timerLocked) return; commitTimer(); try{clock.releasePointerCapture(e.pointerId);}catch(_){/* noop */} e.preventDefault(); }
+function onPointerUp(e){ if(!dragging||timerLocked) return; commitTimer(); endDrag(e); e.preventDefault(); }
+function onPointerCancel(e){ if(!dragging) return; endDrag(e); }
 clock.addEventListener('pointerdown', onPointerDown, {passive:false});
 clock.addEventListener('pointermove', onPointerMove, {passive:false});
 clock.addEventListener('pointerup', onPointerUp, {passive:false});
+clock.addEventListener('pointercancel', onPointerCancel, {passive:false});
 
 // ====== 経過チェック ======
 function tick(){


### PR DESCRIPTION
## Summary
- Safely create the audio context and disable audio features when unsupported
- Show the start gate only when audio APIs are available and hide after unlocking
- Handle pointer cancellation cleanly and reuse the global clock element

## Testing
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc47344bf083338a42eab7db8642fb