### PR TITLE
Cache action bar height to keep canvas size stable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 body{margin:0;font-family:system-ui,-apple-system;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f6f7f9;height:100dvh;overflow:hidden;padding-top:12px;padding-bottom:8px;-webkit-user-select:none;user-select:none}
-:root{--ctrl-size:14px;--pill-min-w:96px}
+:root{--ctrl-size:14px;--pill-min-w:96px;--actions-h:0}
 #controls{margin:18px 0 12px;display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;justify-items:center}
 input[type=range]{width:100%;max-width:400px}
 .pill{background:#eef2ff;padding:6px 12px;border-radius:999px;font-weight:700;font-size:var(--ctrl-size);min-width:var(--pill-min-w);display:inline-flex;align-items:center;justify-content:center}
@@ -7,8 +7,8 @@ input[type=range]{width:100%;max-width:400px}
 #clock{aspect-ratio:1/1;touch-action:none;cursor:pointer}
 #gate{display:none}
 #gate button{padding:14px 18px;font-size:18px;font-weight:800;border:0;border-radius:16px;background:#007aff;color:#fff}
-#actions{visibility:hidden;margin:10px 0 12px;display:flex;gap:12px}
-#actions.visible{visibility:visible}
+#actionsSpace{margin:10px 0 12px;height:var(--actions-h)}
+#actions{display:none;gap:12px}
 #actions button{padding:10px 14px;font-size:16px;font-weight:700;border:0;border-radius:12px;background:#0a84ff;color:#fff}
 #actions button.outline{background:#fff;color:#0a84ff;border:2px solid #0a84ff}
 #confettiLayer{position:fixed;inset:0;pointer-events:none;overflow:visible;z-index:10}

--- a/index.html
+++ b/index.html
@@ -14,9 +14,11 @@
   <span class="pill"><span id="nVal">5</span><span id="nUnit">分</span></span>
 </div>
 <canvas id="clock" width="600" height="600"></canvas>
-<div id="actions">
-  <button id="resetBtn" class="outline">アラーム再設定</button>
-  <button id="nextBtn">終わった。次！</button>
+<div id="actionsSpace">
+  <div id="actions">
+    <button id="resetBtn" class="outline">アラーム再設定</button>
+    <button id="nextBtn">終わった。次！</button>
+  </div>
 </div>
 <script type="module" src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -20,6 +20,21 @@ const gate=$('gate');
 const gateBtn=$('gateBtn');
 const nextBtn=$('nextBtn');
 const resetBtn=$('resetBtn');
+const actions=$('actions');
+
+// Capture action area height once and expose via CSS variable
+const ACTIONS_H = (()=>{
+  if(!actions) return 0;
+  const holder = actions.parentElement;
+  const prevHolderH = holder.style.height;
+  holder.style.height='auto';
+  actions.style.display='flex';
+  const h = actions.offsetHeight;
+  actions.style.display='none';
+  holder.style.height=prevHolderH;
+  document.documentElement.style.setProperty('--actions-h', h+'px');
+  return h;
+})();
 
 // ====== 分針ドラッグ用の状態 ======
 let dragging=false;       // ドラッグ中か
@@ -189,8 +204,8 @@ function resetState(){
   startMin=startTime.getMinutes()+startSec/60;
   startHour=(startTime.getHours()%12)+startMin/60;
   scheduleNextNFrom(startTime);
-  const actions=document.getElementById('actions');
-  if(actions) actions.classList.remove('visible');
+  if(actions) actions.style.display='none';
+  resizeCanvas();
 }
 
 function onNext(){
@@ -308,8 +323,8 @@ function commitTimer(){
   const endH = (endH24%12)||12;
   const endM = endDate.getMinutes();
   speakOrBeep(`タイマースタート。${endH}時${endM}分まであと${rMin}分${rSec}秒です`);
-  const actions=document.getElementById('actions');
-  if(actions) actions.classList.add('visible');
+  if(actions) actions.style.display='flex';
+  resizeCanvas();
   drawClock();
 }
 function onPointerDown(e){
@@ -397,9 +412,8 @@ function tick(){
 function resizeCanvas(){
   const margin = 12;
   const controls = document.getElementById('controls');
-  const actions = document.getElementById('actions');
   const availW = Math.max(100, window.innerWidth - margin*2);
-  const availH = Math.max(100, window.innerHeight - (controls?controls.offsetHeight:0) - (actions?actions.offsetHeight:0) - margin*2);
+  const availH = Math.max(100, window.innerHeight - (controls?controls.offsetHeight:0) - ACTIONS_H - margin*2);
   const size = Math.floor(Math.min(availW, availH));
 
   // apply CSS size
@@ -424,6 +438,8 @@ function resizeCanvas(){
   // center controls to same width as clock
   const controlsEl = document.getElementById('controls');
   if(controlsEl){ controlsEl.style.width = rect.width + 'px'; }
+  const actionsSpaceEl = document.getElementById('actionsSpace');
+  if(actionsSpaceEl){ actionsSpaceEl.style.width = rect.width + 'px'; }
 }
 window.addEventListener('resize', resizeCanvas);
 resizeCanvas();


### PR DESCRIPTION
## Summary
- Cache the action button container height once and expose it via CSS variable
- Reserve action area space with placeholder and toggle display when starting/resetting timer
- Resize canvas using cached height so layout stays stable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bec24ded488333a8a658a18a1415b5