### PR TITLE
Fix syntax errors preventing clock display

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -171,25 +171,20 @@ function confettiBurst(){
   // layer自体は維持（使い回し）
 }
 function showRemainTime(ms){
-  const sec=Math.ceil(ms/1000);
-  const m=Math.floor(sec/60);
-const sec = Math.ceil(ms / 1000);
-const m = Math.floor(sec / 60);
-const text = `${m}分`;
-const el = document.createElement('div');
-el.className = 'remainEffect';
-el.textContent = text;
-const clock = document.getElementById('clock');
-if (clock) {
-  const rect = clock.getBoundingClientRect();
-  const fontSize = rect.width / Math.max(1, text.length);
-  el.style.fontSize = fontSize + 'px';
-}
-document.body.appendChild(el);
-setTimeout(() => { el.remove(); }, 1300);
-
+  const sec = Math.ceil(ms / 1000);
+  const m = Math.floor(sec / 60);
+  const text = `${m}分`;
+  const el = document.createElement('div');
+  el.className = 'remainEffect';
+  el.textContent = text;
+  const clock = document.getElementById('clock');
+  if (clock) {
+    const rect = clock.getBoundingClientRect();
+    const fontSize = rect.width / Math.max(1, text.length);
+    el.style.fontSize = fontSize + 'px';
+  }
   document.body.appendChild(el);
-  setTimeout(()=>{el.remove();},1300);
+  setTimeout(() => { el.remove(); }, 1300);
 }
 
 function resetState(){
@@ -215,6 +210,7 @@ function onNext(){
   }else{
     confettiBurst();
   }
+}
 
 function onResetAlarm(){
   resetState();


### PR DESCRIPTION
## Summary
- Remove duplicated code in `showRemainTime` that caused JavaScript parse errors
- Close `onNext` function to restore timer actions

## Testing
- `node --check js/main.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bec42a50488333944755f639593785