### PR TITLE
中央揃えの改善とタイマー設定の見直し

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,8 +7,9 @@ input[type=range]{width:100%;max-width:400px}
 #clock{aspect-ratio:1/1;touch-action:none;cursor:pointer}
 #gate{display:none}
 #gate button{padding:14px 18px;font-size:18px;font-weight:800;border:0;border-radius:16px;background:#007aff;color:#fff}
-#actionsSpace{margin:10px 0 12px;height:var(--actions-h)}
-#actions{display:none;gap:12px}
+#actionsSpace{margin:10px 0 12px;height:var(--actions-h);display:flex;justify-content:center;align-items:center;text-align:center}
+#actions{display:none;gap:12px;justify-content:center}
+#preMsg{display:block;font-size:16px;font-weight:700}
 #actions button{padding:10px 14px;font-size:16px;font-weight:700;border:0;border-radius:12px;background:#0a84ff;color:#fff}
 #actions button.outline{background:#fff;color:#0a84ff;border:2px solid #0a84ff}
 #confettiLayer{position:fixed;inset:0;pointer-events:none;overflow:visible;z-index:10}

--- a/index.html
+++ b/index.html
@@ -10,13 +10,22 @@
 <div id="gate"><button id="gateBtn">タップで開始</button></div>
 <div id="controls">
   <span id="soundIcon" class="ctrlText">🔊</span>
-  <input id="range" type="range" min="0" max="30" step="1" value="5">
+  <input id="range" type="range" min="0" max="30" step="1" value="5" list="announceTicks">
   <span class="pill"><span id="nVal">5</span><span id="nUnit">分</span></span>
 </div>
+<datalist id="announceTicks">
+  <option value="0" label="0"></option>
+  <option value="1" label="1"></option>
+  <option value="5" label="5"></option>
+  <option value="10" label="10"></option>
+  <option value="15" label="15"></option>
+  <option value="30" label="30"></option>
+</datalist>
 <canvas id="clock" width="600" height="600"></canvas>
 <div id="actionsSpace">
+  <div id="preMsg">次に何をやるか決めてから、<br>タイマーをセットしよう</div>
   <div id="actions">
-    <button id="resetBtn" class="outline">アラーム再設定</button>
+    <button id="resetBtn" class="outline">タイマー再設定</button>
     <button id="nextBtn">終わった。次！</button>
   </div>
 </div>

--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,7 @@ const gateBtn=$('gateBtn');
 const nextBtn=$('nextBtn');
 const resetBtn=$('resetBtn');
 const actions=$('actions');
+const preMsg=$('preMsg');
 
 // Capture action area height once and expose via CSS variable
 const ACTIONS_H = (()=>{
@@ -28,9 +29,11 @@ const ACTIONS_H = (()=>{
   const holder = actions.parentElement;
   const prevHolderH = holder.style.height;
   holder.style.height='auto';
+  if(preMsg) preMsg.style.display='none';
   actions.style.display='flex';
   const h = actions.offsetHeight;
   actions.style.display='none';
+  if(preMsg) preMsg.style.display='';
   holder.style.height=prevHolderH;
   document.documentElement.style.setProperty('--actions-h', h+'px');
   return h;
@@ -206,6 +209,7 @@ function resetState(){
   startHour=(startTime.getHours()%12)+startMin/60;
   scheduleNextNFrom(startTime);
   if(actions) actions.style.display='none';
+  if(preMsg) preMsg.style.display='block';
   resizeCanvas();
 }
 
@@ -216,6 +220,7 @@ function onNext(){
     return;
   }
   confettiBurst();
+  resetState();
 }
 
 function onResetAlarm(){
@@ -230,10 +235,17 @@ function updateSoundUI(){
   if(nUnit) nUnit.textContent = (N<=0)? '' : '分ごと';
   if(soundIcon) soundIcon.textContent = (N<=0)? '🔈' : '🔊';
 }
+const announceMarks=[0,1,5,10,15,30];
 range.oninput=e=>{
-  const v=parseInt(e.target.value,10);
-  N = isNaN(v)?0:v;
-  nVal.textContent = (N<=0)? 'なし' : N;
+  let v=parseInt(e.target.value,10);
+  if(isNaN(v)) v=0;
+  let nearest=announceMarks[0];
+  for(const m of announceMarks){
+    if(Math.abs(m-v) < Math.abs(nearest-v)) nearest=m;
+  }
+  e.target.value=nearest;
+  N=nearest;
+  nVal.textContent=(N<=0)?'なし':N;
   updateSoundUI();
   if(started){
     startTime=new Date();
@@ -326,6 +338,7 @@ function commitTimer(){
   const endM = endDate.getMinutes();
   speakOrBeep(`タイマースタート。${endH}時${endM}分まであと${rMin}分${rSec}秒です`);
   if(actions) actions.style.display='flex';
+  if(preMsg) preMsg.style.display='none';
   resizeCanvas();
   drawClock();
 }


### PR DESCRIPTION
## Summary
- タイマー未設定時に中央メッセージを表示し、ボタン群を中央揃え
- 「終わった。次！」押下でタイマー設定画面に戻るように変更
- アナウンス間隔スライダーに0/1/5/10/15/30の目盛とスナップ機能を追加

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68becdc7ff9c83338bd0400ebaa1e746