### PR TITLE
中央揃えの改善とタイマー設定の見直し

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,14 +1,15 @@
-body{margin:0;font-family:system-ui,-apple-system;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f6f7f9;height:100dvh;overflow:hidden;padding-top:12px;padding-bottom:8px;-webkit-user-select:none;user-select:none}
+body{margin:0;font-family:system-ui,-apple-system;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f6f7f9;min-height:100dvh;overflow-x:hidden;overflow-y:auto;padding-top:12px;padding-bottom:8px;-webkit-user-select:none;user-select:none}
 :root{--ctrl-size:14px;--pill-min-w:96px;--actions-h:0}
-#controls{margin:18px 0 12px;display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;justify-items:center}
+#controls{margin:10px 0 12px;display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;justify-items:center}
 input[type=range]{width:100%;max-width:400px}
 .pill{background:#eef2ff;padding:6px 12px;border-radius:999px;font-weight:700;font-size:var(--ctrl-size);min-width:var(--pill-min-w);display:inline-flex;align-items:center;justify-content:center}
 .ctrlText{font-size:var(--ctrl-size)}
 #clock{aspect-ratio:1/1;touch-action:none;cursor:pointer}
 #gate{display:none}
 #gate button{padding:14px 18px;font-size:18px;font-weight:800;border:0;border-radius:16px;background:#007aff;color:#fff}
-#actionsSpace{margin:10px 0 12px;height:var(--actions-h)}
-#actions{display:none;gap:12px}
+#actionsSpace{margin:18px 0 12px;height:var(--actions-h);display:flex;justify-content:center;align-items:center;text-align:center}
+#actions{display:none;gap:12px;justify-content:center}
+#preMsg{display:block;font-size:16px;font-weight:700}
 #actions button{padding:10px 14px;font-size:16px;font-weight:700;border:0;border-radius:12px;background:#0a84ff;color:#fff}
 #actions button.outline{background:#fff;color:#0a84ff;border:2px solid #0a84ff}
 #confettiLayer{position:fixed;inset:0;pointer-events:none;overflow:visible;z-index:10}

--- a/index.html
+++ b/index.html
@@ -8,18 +8,27 @@
 </head>
 <body>
 <div id="gate"><button id="gateBtn">タップで開始</button></div>
-<div id="controls">
-  <span id="soundIcon" class="ctrlText">🔊</span>
-  <input id="range" type="range" min="0" max="30" step="1" value="5">
-  <span class="pill"><span id="nVal">5</span><span id="nUnit">分</span></span>
-</div>
-<canvas id="clock" width="600" height="600"></canvas>
 <div id="actionsSpace">
+  <div id="preMsg">次に何をやるか決めてから、<br>タイマーをセットしよう</div>
   <div id="actions">
-    <button id="resetBtn" class="outline">アラーム再設定</button>
+    <button id="resetBtn" class="outline">タイマー再設定</button>
     <button id="nextBtn">終わった。次！</button>
   </div>
 </div>
+<canvas id="clock" width="600" height="600"></canvas>
+<div id="controls">
+  <span id="soundIcon" class="ctrlText">🔊</span>
+  <input id="range" type="range" min="0" max="30" step="1" value="5" list="announceTicks">
+  <span class="pill"><span id="nVal">5</span><span id="nUnit">分</span></span>
+</div>
+<datalist id="announceTicks">
+  <option value="0" label="0"></option>
+  <option value="1" label="1"></option>
+  <option value="5" label="5"></option>
+  <option value="10" label="10"></option>
+  <option value="15" label="15"></option>
+  <option value="30" label="30"></option>
+</datalist>
 <script type="module" src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- タイマー未設定時に中央メッセージを表示し、ボタン群を中央揃え
- 「終わった。次！」押下でタイマー設定画面に戻るように変更
- アナウンス間隔スライダーに0/1/5/10/15/30の目盛を付与し、1分刻みで調整できるように変更
- 「終わった。次！」が常にリセットされるように修正し、残り分表示の読み上げを除去
- 画面下部が見切れないようにレイアウトを調整
- スライダーとアクションボタンの配置を入れ替え、時計を挟むレイアウトに変更
- 針の明滅時は60fps、非明滅時は1fpsで描画する省電力制御を実装

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68becdc7ff9c83338bd0400ebaa1e746