### PR TITLE
Clarify time announcements and slider label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 body{margin:0;font-family:system-ui,-apple-system;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f6f7f9;min-height:100dvh;overflow-x:hidden;overflow-y:auto;padding-top:12px;padding-bottom:8px;-webkit-user-select:none;user-select:none}
-:root{--ctrl-size:14px;--pill-min-w:96px;--actions-h:0}
+:root{--ctrl-size:14px;--pill-min-w:96px;--actions-h:0;--pre-msg-size:16px}
 #controls{margin:10px 0 12px;display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;justify-items:center}
 input[type=range]{width:100%;max-width:400px}
 .pill{background:#eef2ff;padding:6px 12px;border-radius:999px;font-weight:700;font-size:var(--ctrl-size);min-width:var(--pill-min-w);display:inline-flex;align-items:center;justify-content:center}
@@ -9,7 +9,7 @@ input[type=range]{width:100%;max-width:400px}
 #gate button{padding:14px 18px;font-size:18px;font-weight:800;border:0;border-radius:16px;background:#007aff;color:#fff}
 #actionsSpace{margin:10px 0 12px;height:var(--actions-h);display:flex;justify-content:center;align-items:center;text-align:center}
 #actions{display:none;gap:12px;justify-content:center}
-#preMsg{display:block;font-size:16px;font-weight:700}
+#preMsg{display:block;font-size:var(--pre-msg-size);font-weight:700;white-space:nowrap}
 #actions button{padding:10px 14px;font-size:16px;font-weight:700;border:0;border-radius:12px;background:#0a84ff;color:#fff}
 #actions button.outline{background:#fff;color:#0a84ff;border:2px solid #0a84ff}
 #confettiLayer{position:fixed;inset:0;pointer-events:none;overflow:visible;z-index:10}

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
 <div id="gate"><button id="gateBtn">タップで開始</button></div>
 <div id="actionsSpace">
-  <div id="preMsg">やることを決めてから、<br>タイマーをセットしよう</div>
+  <div id="preMsg">やることを決めてから、タイマーをセットしよう</div>
   <div id="actions">
     <button id="resetBtn" class="outline">タイマー再設定</button>
     <button id="nextBtn">終わった。次！</button>
@@ -19,7 +19,7 @@
 <div id="controls">
   <span id="soundIcon" class="ctrlText">🔊</span>
   <input id="range" type="range" min="0" max="30" step="1" value="5" list="announceTicks">
-  <span class="pill"><span id="nVal">5</span><span id="nUnit">分</span></span>
+    <span class="pill"><span id="nVal">5</span><span id="nUnit">分ごと</span></span>
 </div>
 <datalist id="announceTicks">
   <option value="0" label="0"></option>

--- a/js/main.js
+++ b/js/main.js
@@ -90,6 +90,11 @@ function speakOrBeep(msg){
   }
 }
 
+// m===0 のときは「○時ちょうど」とする
+function formatTime(h,m){
+  return (m===0)? `${h}時ちょうど` : `${h}時${m}分`;
+}
+
 // ====== タップで開始 ======
 function unlock(){
   audioUnlocked=true;
@@ -245,7 +250,7 @@ function onResetAlarm(){
 
 // ====== Nを変更したらリスタート ======
 function updateSoundUI(){
-  if(nUnit) nUnit.textContent = (N<=0)? '' : '分';
+  if(nUnit) nUnit.textContent = (N<=0)? '' : '分ごと';
   if(soundIcon) soundIcon.textContent = (N<=0)? '🔈' : '🔊';
 }
 // アナウンス間隔スライダー: 目盛りは参照用とし、1分単位で調整可能
@@ -345,7 +350,8 @@ function commitTimer(){
   const endH24 = endDate.getHours();
   const endH = (endH24%12)||12;
   const endM = endDate.getMinutes();
-  speakOrBeep(`タイマースタート。${endH}時${endM}分まであと${rMin}分${rSec}秒です`);
+  const timeStr = formatTime(endH,endM);
+  speakOrBeep(`タイマースタート。${timeStr}まであと${rMin}分${rSec}秒です`);
   if(actions) actions.style.display='flex';
   if(preMsg) preMsg.style.display='none';
   resizeCanvas();
@@ -375,7 +381,7 @@ function tick(){
       endAnnounced=true;
       const h=((endDate.getHours()%12)||12);
       const m=endDate.getMinutes();
-      speakOrBeep(`はい、終わりです。${h}時${m}分になりました`);
+      speakOrBeep(`はい、終わりです。${formatTime(h,m)}になりました`);
       if(!overrunStart) overrunStart=now;
       if(nNextAnnounce) nNextAnnounce = addMinutes(endDate, N);
       return;
@@ -402,7 +408,7 @@ function tick(){
         const h=((endDate.getHours()%12)||12);
         const m=endDate.getMinutes();
         const overMin = Math.max(0, Math.floor((minuteStartTs - endDate.getTime())/60000));
-        msg = `${h}時${m}分からもう${overMin}分がすぎています`;
+        msg = `${formatTime(h,m)}からもう${overMin}分がすぎています`;
       }else{
         if(timerSet && endDate){
           const diffMs=endDate.getTime() - minuteStartTs;
@@ -451,11 +457,14 @@ function resizeCanvas(){
   else ctx.setTransform(1,0,0,1,0,0);
   ctx.scale(dpr,dpr);
 
-  // update control text sizing to ~2/3 of numeral size
+  // update control/preMsg text sizing relative to numeral size
   const R = Math.min(rect.width, rect.height) / 2 - 16;
-  const ctrlPx = Math.max(12, Math.round(R*0.14*2/3));
+  const numeralPx = Math.round(R*0.14);
+  const ctrlPx = Math.max(12, Math.round(numeralPx*2/3));
+  const preMsgPx = Math.max(12, Math.round(numeralPx*0.5));
   document.documentElement.style.setProperty('--ctrl-size', ctrlPx+'px');
   document.documentElement.style.setProperty('--pill-min-w', Math.round(ctrlPx*5.6)+'px');
+  document.documentElement.style.setProperty('--pre-msg-size', preMsgPx+'px');
   // center controls to same width as clock
   const controlsEl = document.getElementById('controls');
   if(controlsEl){ controlsEl.style.width = rect.width + 'px'; }


### PR DESCRIPTION
## Summary
- Speak "○時ちょうど" instead of "○時0分" and use new time formatting across announcements
- Keep the pre-message on a single line and size it to half of clock numerals
- Show interval label as "なし" or "○分ごと" next to the slider

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68befb0ff5d883339a9dab3b986cf74c